### PR TITLE
Fix: update pump.fun API to v3, BC% momentum monitor

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -110,10 +110,10 @@ async def main(dry_run: bool) -> None:
         rpc = None
         print("[bot] DRY RUN — monitoring only, no trades will execute")
 
+    print("[bot] v3 STARTING", flush=True)
     print(
-        f"[bot] Watching pump.fun for momentum moves "
-        f"(BC +{config.MIN_BC_RISE_PCT}–{config.MAX_BC_RISE_PCT}pts in {config.MOMENTUM_WINDOW_SEC}s, "
-        f"max BC {config.MAX_BC_PCT}%) …"
+        f"[bot] BC momentum: +{config.MIN_BC_RISE_PCT}-{config.MAX_BC_RISE_PCT}pts/{config.MOMENTUM_WINDOW_SEC}s",
+        flush=True,
     )
 
     queue        = asyncio.Queue()

--- a/bot.py
+++ b/bot.py
@@ -112,8 +112,8 @@ async def main(dry_run: bool) -> None:
 
     print(
         f"[bot] Watching pump.fun for momentum moves "
-        f"(+{config.MIN_PRICE_RISE_PCT}%–{config.MAX_PRICE_RISE_PCT}% in {config.MOMENTUM_WINDOW_SEC}s, "
-        f"mcap ${config.MIN_MCAP_USD:,}–${config.MAX_MCAP_USD:,}) …"
+        f"(BC +{config.MIN_BC_RISE_PCT}–{config.MAX_BC_RISE_PCT}pts in {config.MOMENTUM_WINDOW_SEC}s, "
+        f"max BC {config.MAX_BC_PCT}%) …"
     )
 
     queue        = asyncio.Queue()

--- a/config.py
+++ b/config.py
@@ -1,36 +1,35 @@
 import os
 
-# ── Solana RPC ────────────────────────────────────────────────────────────────
+# ── Solana RPC ──────────────────────────────────────────────────────
 # Override with a faster dedicated RPC (Helius, QuickNode, etc.) via env var
 RPC_URL = os.environ.get("SOLANA_RPC_URL", "https://api.mainnet-beta.solana.com")
 
-# ── Wallet ────────────────────────────────────────────────────────────────────
+# ── Wallet ────────────────────────────────────────────────────────────
 KEYPAIR_PATH = "./keypair.json"
 
-# ── Trade sizing ──────────────────────────────────────────────────────────────
+# ── Trade sizing ──────────────────────────────────────────────────────
 # Bot bets a % of spendable balance each trade so it compounds wins and
 # scales back after losses — you should never need to top it up.
 TRADE_PCT       = float(os.environ.get("TRADE_PCT", "0.30"))   # 30% of spendable per trade
 GAS_RESERVE_SOL = float(os.environ.get("GAS_RESERVE_SOL", "0.05"))  # always kept back for fees
 MIN_TRADE_SOL   = 0.01      # don't bother trading below this (fees would eat it)
 
-# ── pump.fun monitoring ───────────────────────────────────────────────────────
-# Momentum-based: buy when price rises fast, not based on bonding curve %
-MOMENTUM_WINDOW_SEC  = 60   # measure price rise over this window
-MIN_PRICE_RISE_PCT   = 25   # must have risen at least 25% in the window
-MAX_PRICE_RISE_PCT   = 300  # skip if >300% in window — likely bot manipulation
-MIN_MCAP_USD         = 8_000    # ignore micro-dust coins
-MAX_MCAP_USD         = 80_000   # ignore coins already too pumped to run
+# ── pump.fun monitoring ───────────────────────────────────────────────────
+# Track bonding curve % rise — reliable field that's always present
+MOMENTUM_WINDOW_SEC  = 60   # measure BC rise over this window
+MIN_BC_RISE_PCT      = 5    # fire when BC rises 5+ points in the window
+MAX_BC_RISE_PCT      = 40   # skip if >40pts rise — likely coordinated bot pump
+MAX_BC_PCT           = 90   # skip coins already above 90% (graduation chaos)
 
-# ── Exit conditions (whichever triggers first) ────────────────────────────────
+# ── Exit conditions (whichever triggers first) ────────────────────────────
 PROFIT_TARGET_PCT = 20      # Sell when up 20%
 STOP_LOSS_PCT     = 10      # Sell when down 10%
 MAX_HOLD_SECONDS  = 120     # Force sell after 2 minutes
 
-# ── Timing ────────────────────────────────────────────────────────────────────
+# ── Timing ──────────────────────────────────────────────────────────────
 POLL_INTERVAL_SEC = 0.5     # How often to poll pump.fun and check positions
 
-# ── Jupiter ───────────────────────────────────────────────────────────────────
+# ── Jupiter ─────────────────────────────────────────────────────────────
 SLIPPAGE_BPS = 300          # 3% slippage tolerance
 
 # Priority fee sent to Jupiter so txs land fast during congestion
@@ -41,18 +40,18 @@ PRIORITY_FEE = "auto"
 # At ~$130/SOL, $5 ≈ 0.038 SOL — used to calculate true net profit.
 GAS_COST_ROUNDTRIP_SOL = float(os.environ.get("GAS_COST_ROUNDTRIP_SOL", "0.038"))
 
-# ── Token addresses ───────────────────────────────────────────────────────────
+# ── Token addresses ───────────────────────────────────────────────────────
 SOL_MINT  = "So11111111111111111111111111111111111111112"
 USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
 
-# ── Profit parking ────────────────────────────────────────────────────────────
+# ── Profit parking ─────────────────────────────────────────────────────────
 # After a winning trade, keep profit aside so it's never re-risked.
 # PARK_PROFITS=True  → hold profit as SOL (no extra swap, no extra gas)
 # PARK_AS_USDC=True  → additionally convert profit to USDC (costs one more tx)
 PARK_PROFITS  = True
 PARK_AS_USDC  = False  # set True only if you want hard USDC conversion
 
-# ── Coin filters ──────────────────────────────────────────────────────────────
+# ── Coin filters ───────────────────────────────────────────────────────────
 # Holder concentration: skip if top real holders (excl. bonding curve) own > this %
 MAX_TOP_HOLDER_PCT   = 35   # no single wallet should hold more than 35%
 MAX_TOP5_COMBINED_PCT = 50  # top 5 real wallets combined shouldn't exceed 50%

--- a/monitor.py
+++ b/monitor.py
@@ -17,7 +17,7 @@ import aiohttp
 
 import config
 
-PUMPFUN_API = "https://frontend-api.pump.fun/coins"
+PUMPFUN_API = "https://frontend-api-v3.pump.fun/coins"
 
 # mint -> deque of (timestamp, bonding_pct) snapshots
 _bc_history: dict[str, deque] = defaultdict(lambda: deque())

--- a/monitor.py
+++ b/monitor.py
@@ -1,12 +1,12 @@
 """
-Momentum monitor — catches coins in the early stage of a pump.
+Momentum monitor — catches coins with rapidly rising bonding curve %.
 
 Strategy:
-  1. Poll pump.fun for recently active coins every POLL_INTERVAL_SEC.
-  2. Keep a rolling price history for each coin.
-  3. When a coin's price rises >= MIN_PRICE_RISE_PCT over MOMENTUM_WINDOW_SEC
-     AND is not a suspicious spike (> MAX_PRICE_RISE_PCT), queue it for buying.
-  4. Each coin is only queued once per session (seen_mints guard).
+  1. Poll pump.fun for coins sorted by recent activity.
+  2. Track bonding_curve_percentage over time per coin.
+  3. Fire when a coin's bonding % rises >= MIN_BC_RISE_PCT in the window
+     AND is not already too close to graduation (>= MAX_BC_PCT).
+  4. Each mint is only queued once per session.
 """
 
 import asyncio
@@ -19,43 +19,43 @@ import config
 
 PUMPFUN_API = "https://frontend-api.pump.fun/coins"
 
-# mint -> deque of (timestamp, price) snapshots within the window
-_price_history: dict[str, deque] = defaultdict(lambda: deque())
+# mint -> deque of (timestamp, bonding_pct) snapshots
+_bc_history: dict[str, deque] = defaultdict(lambda: deque())
 
 
-def _current_price(coin: dict) -> float:
-    """Extract USD price from whichever field exists."""
+def _bc_pct(coin: dict) -> float:
     return float(
-        coin.get("price")
-        or coin.get("usd_price")
-        or coin.get("last_price")
+        coin.get("bonding_curve_percentage")
+        or coin.get("bonding_curve_progress")
+        or coin.get("progress")
         or 0
     )
 
 
-def _mcap(coin: dict) -> float:
-    return float(coin.get("usd_market_cap") or coin.get("market_cap_usd") or 0)
-
-
 async def _fetch_active(session: aiohttp.ClientSession) -> list[dict]:
-    """Fetch the most recently traded coins."""
     params = {
-        "sort":         "last_trade_unix_timestamp",
-        "order":        "DESC",
-        "limit":        50,
-        "includeNsfw":  "true",
+        "sort":        "last_trade_unix_timestamp",
+        "order":       "DESC",
+        "limit":       50,
+        "includeNsfw": "true",
     }
     try:
         async with session.get(
             PUMPFUN_API,
             params=params,
-            timeout=aiohttp.ClientTimeout(total=5),
+            timeout=aiohttp.ClientTimeout(total=10),
         ) as resp:
             if resp.status != 200:
+                body = await resp.text()
+                print(f"[monitor] API {resp.status}: {body[:200]}", flush=True)
                 return []
-            data = await resp.json()
+            data = await resp.json(content_type=None)
+            if not isinstance(data, list):
+                print(f"[monitor] Unexpected response type: {type(data)} — {str(data)[:200]}", flush=True)
+                return []
+            print(f"[monitor] API ok — {len(data)} coins raw", flush=True)
     except Exception as e:
-        print(f"[monitor] Fetch error: {e}")
+        print(f"[monitor] Fetch error: {type(e).__name__}: {e}", flush=True)
         return []
 
     results = []
@@ -63,30 +63,22 @@ async def _fetch_active(session: aiohttp.ClientSession) -> list[dict]:
         if not isinstance(coin, dict):
             continue
         if coin.get("complete"):
-            continue  # already graduated, skip
-        mcap = _mcap(coin)
-        if not (config.MIN_MCAP_USD <= mcap <= config.MAX_MCAP_USD):
             continue
-        price = _current_price(coin)
-        if price <= 0:
-            continue
+        bc = _bc_pct(coin)
+        if bc >= config.MAX_BC_PCT:
+            continue  # too close to graduation chaos
         results.append(coin)
     return results
 
 
 def _record_and_check(coin: dict) -> tuple[bool, float]:
-    """
-    Add latest price snapshot. Return (should_buy, rise_pct) if momentum
-    threshold crossed, else (False, 0).
-    """
-    mint  = coin["mint"]
-    price = _current_price(coin)
-    now   = time.time()
+    mint = coin["mint"]
+    bc   = _bc_pct(coin)
+    now  = time.time()
 
-    history = _price_history[mint]
-    history.append((now, price))
+    history = _bc_history[mint]
+    history.append((now, bc))
 
-    # Drop snapshots outside the momentum window
     cutoff = now - config.MOMENTUM_WINDOW_SEC
     while history and history[0][0] < cutoff:
         history.popleft()
@@ -94,40 +86,54 @@ def _record_and_check(coin: dict) -> tuple[bool, float]:
     if len(history) < 2:
         return False, 0.0
 
-    oldest_price = history[0][1]
-    if oldest_price <= 0:
-        return False, 0.0
+    rise = bc - history[0][1]
 
-    rise_pct = (price - oldest_price) / oldest_price * 100
+    if rise >= config.MIN_BC_RISE_PCT:
+        if rise > config.MAX_BC_RISE_PCT:
+            return False, rise  # too fast — bots
+        return True, rise
 
-    if rise_pct >= config.MIN_PRICE_RISE_PCT:
-        if rise_pct > config.MAX_PRICE_RISE_PCT:
-            return False, rise_pct  # suspicious spike — skip
-        return True, rise_pct
-
-    return False, rise_pct
+    return False, rise
 
 
-async def run(queue: asyncio.Queue, seen_mints: set) -> None:
-    """Continuously poll pump.fun and enqueue momentum candidates."""
+async def _run_inner(queue: asyncio.Queue, seen_mints: set) -> None:
+    _tick = 0
     async with aiohttp.ClientSession() as session:
         while True:
             coins = await _fetch_active(session)
+            _tick += 1
+
+            if _tick % 20 == 1:
+                print(f"[monitor] tick {_tick} | {len(coins)} candidates", flush=True)
+                if coins:
+                    s = coins[0]
+                    print(f"[monitor] sample: {s.get('symbol')} bc={_bc_pct(s):.1f}%", flush=True)
+
             for coin in coins:
                 mint = coin.get("mint")
                 if not mint or mint in seen_mints:
                     continue
 
-                should_buy, rise_pct = _record_and_check(coin)
+                should_buy, rise = _record_and_check(coin)
+
                 if should_buy:
                     seen_mints.add(mint)
                     symbol = coin.get("symbol", "???")
-                    mcap   = _mcap(coin)
                     print(
-                        f"[monitor] MOMENTUM {symbol} ({mint[:8]}…) "
-                        f"+{rise_pct:.1f}% in {config.MOMENTUM_WINDOW_SEC}s "
-                        f"| mcap ${mcap:,.0f}"
+                        f"[monitor] MOMENTUM {symbol} ({mint[:8]}\u2026) "
+                        f"BC +{rise:.1f}pts in {config.MOMENTUM_WINDOW_SEC}s",
+                        flush=True,
                     )
                     await queue.put(coin)
 
             await asyncio.sleep(config.POLL_INTERVAL_SEC)
+
+
+async def run(queue: asyncio.Queue, seen_mints: set) -> None:
+    try:
+        await _run_inner(queue, seen_mints)
+    except Exception as exc:
+        import traceback
+        print(f"[monitor] FATAL: {exc}", flush=True)
+        traceback.print_exc()
+        raise

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ solders>=0.21.0
 solana>=0.34.0
 aiohttp>=3.9.0
 base58>=2.1.0
+python-dotenv>=1.0.0


### PR DESCRIPTION
## What's broken
Railway is running a stale cached build using the old `frontend-api.pump.fun` endpoint, which is returning 530 errors. The monitor task was failing silently, leaving the bot stuck waiting forever with no output — causing Railway to restart it every ~5 minutes.

## What this fixes
- **`frontend-api-v3.pump.fun`** — updated API URL to the working v3 endpoint
- **BC% momentum monitor** — replaced unreliable price/mcap fields with `bonding_curve_percentage` (always present), fires when BC rises 5–40pts in 60s
- **Exception surfacing** — monitor task now prints `[monitor] FATAL:` + traceback if it crashes, so silent failures are visible
- **Startup tag** — prints `[bot] v3 STARTING` so you can confirm the new build deployed
- **python-dotenv** — added to requirements to support local `.env` files

## After merging
Railway will rebuild and redeploy automatically. You should see `[monitor] API ok — 50 coins raw` logs every 0.5s confirming the monitor is healthy.