### PR TITLE
Fix rug-pull losses, duplicate re-buys, and orphaned positions

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -29,21 +29,29 @@ def _task_error_handler(task: asyncio.Task) -> None:
 async def _monitor_existing(session, rpc, keypair, trade, active):
     """Sell a position recovered from a previous run as quickly as possible."""
     symbol = trade.symbol
+    _sold = False
     try:
         print(f"[bot] Recovered position: {symbol} — selling immediately", flush=True)
         for attempt in range(1, 4):
             sol_back = await trader.sell(session, rpc, keypair, trade, "RESTART RECOVERY")
             if sol_back > 0:
+                _sold = True
                 break
             await asyncio.sleep(3)
+        if not _sold:
+            print(f"[bot] Recovery sell failed for {symbol} — keeping in positions.json", flush=True)
     finally:
-        positions.remove(trade.mint)
+        if _sold:
+            positions.remove(trade.mint)
         active.discard(trade.mint)
 
 
 async def _handle(session, rpc, keypair, coin, dry_run, active):
     mint   = coin.get("mint")
     symbol = coin.get("symbol", "???")
+    trade           = None   # set only after a successful buy
+    _position_sold  = False
+    _stop_loss_exit = False
     try:
         ok, reason = await filters.passes_all(session, rpc, coin)
         if not ok:
@@ -72,11 +80,12 @@ async def _handle(session, rpc, keypair, coin, dry_run, active):
         peak_pnl_time = time.time()
         none_since    = None
         while True:
-            await asyncio.sleep(config.POLL_INTERVAL_SEC)
+            await asyncio.sleep(config.POSITION_POLL_SEC)
             elapsed = trade.elapsed()
 
             if elapsed >= config.MAX_HOLD_SECONDS:
-                await trader.sell(session, rpc, keypair, trade, "TIME LIMIT")
+                sol_back = await trader.sell(session, rpc, keypair, trade, "TIME LIMIT")
+                _position_sold = sol_back > 0
                 break
 
             value = await trader.current_value_sol(session, trade)
@@ -84,7 +93,8 @@ async def _handle(session, rpc, keypair, coin, dry_run, active):
                 if none_since is None:
                     none_since = time.time()
                 elif time.time() - none_since >= 10:
-                    await trader.sell(session, rpc, keypair, trade, "NO PRICE 30s")
+                    sol_back = await trader.sell(session, rpc, keypair, trade, "NO PRICE 30s")
+                    _position_sold = sol_back > 0
                     break
                 continue
             none_since = None
@@ -99,6 +109,7 @@ async def _handle(session, rpc, keypair, coin, dry_run, active):
 
             if pnl >= config.PROFIT_TARGET_PCT:
                 sol_back = await trader.sell(session, rpc, keypair, trade, "TAKE PROFIT")
+                _position_sold = sol_back > 0
                 if config.PARK_PROFITS and sol_back > trade.sol_spent:
                     gain  = sol_back - trade.sol_spent
                     total = profits.add(gain)
@@ -106,20 +117,30 @@ async def _handle(session, rpc, keypair, coin, dry_run, active):
                 break
             elif peak_pnl >= config.TRAIL_ACTIVATE_PCT and pnl <= peak_pnl - config.TRAIL_DRAWDOWN_PCT:
                 sol_back = await trader.sell(session, rpc, keypair, trade, f"TRAILING STOP (peak {peak_pnl:+.1f}%)")
+                _position_sold = sol_back > 0
                 if config.PARK_PROFITS and sol_back > trade.sol_spent:
                     gain  = sol_back - trade.sol_spent
                     total = profits.add(gain)
                     print(f"[bot] Parked +{gain:.4f} SOL (running total: {total:.4f} SOL)", flush=True)
                 break
             elif pnl > 0.5 and elapsed >= 20 and time.time() - peak_pnl_time > 30:
-                await trader.sell(session, rpc, keypair, trade, "MOMENTUM STALL")
+                sol_back = await trader.sell(session, rpc, keypair, trade, "MOMENTUM STALL")
+                _position_sold = sol_back > 0
                 break
             elif pnl <= -dyn_stop:
-                await trader.sell(session, rpc, keypair, trade, f"STOP LOSS ({dyn_stop:.0f}%)")
+                _stop_loss_exit = True
+                sol_back = await trader.sell(session, rpc, keypair, trade, f"STOP LOSS ({dyn_stop:.0f}%)")
+                _position_sold = sol_back > 0
                 break
     finally:
-        positions.remove(mint)
+        if _position_sold:
+            positions.remove(mint)
+        elif trade is not None:
+            # Buy succeeded but all sell attempts failed — keep in positions.json for recovery
+            print(f"[bot] Sell failed for {symbol} — position kept in positions.json for recovery", flush=True)
         active.discard(mint)
+        if _stop_loss_exit:
+            monitor.block_mint(mint)
 
 
 async def main(dry_run: bool) -> None:

--- a/config.py
+++ b/config.py
@@ -20,7 +20,9 @@ MAX_HOLD_SECONDS  = 90
 TRAIL_ACTIVATE_PCT = 5
 TRAIL_DRAWDOWN_PCT = 5
 
-POLL_INTERVAL_SEC = 2.0
+POLL_INTERVAL_SEC    = 2.0   # monitor fetch interval
+POSITION_POLL_SEC    = 0.5   # position P&L check interval (faster to catch rugs)
+MAX_BC_RISE_PCT      = 20.0  # reject signals with extreme pumps (likely coordinated rug setup)
 
 SLIPPAGE_BPS = 2000
 PRIORITY_FEE = "auto"

--- a/monitor.py
+++ b/monitor.py
@@ -31,8 +31,17 @@ _bc_history: dict[str, deque] = defaultdict(lambda: deque())
 _signal_times: dict[str, float] = {}
 SIGNAL_COOLDOWN_SEC = 600  # re-allow entry after 10 minutes
 
+# Mints permanently blocked from re-signaling this session (e.g. after stop-loss exit)
+_permanent_blocks: set = set()
+
 _err_count = 0
 _logged_sample = False
+
+
+def block_mint(mint: str) -> None:
+    """Permanently block a mint from re-signaling this session (called after stop-loss exit)."""
+    _permanent_blocks.add(mint)
+    print(f"[monitor] Blocked {mint[:8]}… from re-entry this session", flush=True)
 
 
 def _bc_pct(coin: dict) -> float:
@@ -143,8 +152,10 @@ def _check_momentum(coin: dict) -> tuple[bool, float]:
     readings = [bc for _, bc in history]
     total_rise = readings[-1] - readings[0]
 
-    # Require net rise meets threshold
+    # Require net rise meets threshold but isn't an extreme pump (likely coordinated rug)
     if total_rise < config.MIN_BC_RISE_PCT:
+        return False, total_rise
+    if total_rise > config.MAX_BC_RISE_PCT:
         return False, total_rise
 
     # Require price is still rising NOW — last reading must be higher than 2 readings ago
@@ -190,7 +201,7 @@ async def _run_inner(queue: asyncio.Queue, seen_mints: set) -> None:
 
             for coin in coins:
                 mint = coin.get("mint")
-                if not mint or mint in seen_mints:
+                if not mint or mint in seen_mints or mint in _permanent_blocks:
                     continue
 
                 bc = _bc_pct(coin)


### PR DESCRIPTION
## What was broken

The bot was buying coins like ODYSSEY that showed +42pts BC rise in 20s — a coordinated pump-and-dump. By the time the buy landed on-chain, the rug had already happened. P&L was -43% at held=2s with peak=+0.0% (never went positive).

Additionally, after a stop-loss exit the same coin could be re-bought 10 minutes later into the same downtrend, stacking losses.

## Fixes

1. **Extreme pump filter** — signals where BC rose >20pts in the window are rejected. The ODYSSEY +42pts signal would have been blocked.

2. **Stop-loss re-entry block** — after any stop-loss exit, the coin is permanently blocked from re-signaling for the rest of the session.

3. **Faster position polling** — P&L checked every 0.5s instead of 2s, giving 4x more chances to catch the +8% take-profit before a rug completes.

4. **Orphaned position fix** — `positions.remove()` now only runs if the sell actually succeeded. Failed sells stay in `open_positions.json` for recovery on restart.