### PR TITLE
Overhaul: BC zone, balance-confirm sells, house money, stall exit

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -49,14 +49,15 @@ async def _monitor_existing(session, rpc, keypair, trade, active):
 async def _handle(session, rpc, keypair, coin, dry_run, active):
     mint   = coin.get("mint")
     symbol = coin.get("symbol", "???")
-    trade           = None   # set only after a successful buy
-    _position_sold  = False
+    trade          = None
+    _position_sold = False
     _stop_loss_exit = False
-    _partial_sold   = False
+
     try:
         ok, reason = await filters.passes_all(session, rpc, coin)
         if not ok:
             return
+
         if dry_run:
             print(f"[bot] [DRY RUN] PASS {symbol}", flush=True)
             return
@@ -71,15 +72,21 @@ async def _handle(session, rpc, keypair, coin, dry_run, active):
             print(f"[bot] Skipping {symbol} — only {spendable:.4f} SOL spendable", flush=True)
             return
 
-        print(f"[bot] Buying {symbol} | bal={balance_sol:.4f} spendable={spendable:.4f} bet={buy_amount:.4f} SOL", flush=True)
+        print(
+            f"[bot] Buying {symbol} | bal={balance_sol:.4f} spendable={spendable:.4f} bet={buy_amount:.4f} SOL",
+            flush=True,
+        )
+
         trade = await trader.buy(session, rpc, keypair, mint, symbol, buy_amount)
         if trade is None:
             return
+
         positions.record(trade)
 
         peak_pnl      = 0.0
         peak_pnl_time = time.time()
         none_since    = None
+
         while True:
             await asyncio.sleep(config.POSITION_POLL_SEC)
             elapsed = trade.elapsed()
@@ -94,27 +101,39 @@ async def _handle(session, rpc, keypair, coin, dry_run, active):
                 if none_since is None:
                     none_since = time.time()
                 elif time.time() - none_since >= 10:
-                    sol_back = await trader.sell(session, rpc, keypair, trade, "NO PRICE 30s")
+                    sol_back = await trader.sell(session, rpc, keypair, trade, "NO PRICE 10s")
                     _position_sold = sol_back > 0
                     break
                 continue
+
             none_since = None
             pnl = trade.pnl_pct(value)
+
             if pnl > peak_pnl:
                 peak_pnl      = pnl
                 peak_pnl_time = time.time()
-            print(f"[bot] {symbol} P&L={pnl:+.1f}% peak={peak_pnl:+.1f}% held={elapsed:.0f}s", flush=True)
+
+            print(
+                f"[bot] {symbol} P&L={pnl:+.1f}% peak={peak_pnl:+.1f}% held={elapsed:.0f}s",
+                flush=True,
+            )
+
+            # House money: sell 50% at +10%, let the rest ride free
+            if pnl >= 10.0 and not trade._half_sold:
+                sol_back = await trader.sell_partial(
+                    session, rpc, keypair, trade, 0.5, "HOUSE MONEY +10%"
+                )
+                if sol_back > 0:
+                    trade._half_sold = True
+                    if config.PARK_PROFITS and sol_back > trade.sol_spent * 0.5:
+                        gain  = sol_back - trade.sol_spent * 0.5
+                        total = profits.add(gain)
+                        print(f"[bot] Parked +{gain:.4f} SOL (running total: {total:.4f} SOL)", flush=True)
+                # Continue managing the remaining 50%
+                continue
 
             # Dynamic stop: full -5% for first 30s, tightens to -3% after
             dyn_stop = config.STOP_LOSS_PCT if elapsed < 30 else max(3.0, config.STOP_LOSS_PCT * 0.6)
-
-            if not _partial_sold and pnl >= 10.0:
-                sol_back = await trader.sell_partial(session, rpc, keypair, trade, 50)
-                if sol_back > 0:
-                    _partial_sold = True
-                    trade.token_amount //= 2
-                    trade.sol_spent = 0.0  # remainder is house money
-                    print(f"[bot] Partial sell 50% {symbol} — remainder is house money", flush=True)
 
             if pnl >= config.PROFIT_TARGET_PCT:
                 sol_back = await trader.sell(session, rpc, keypair, trade, "TAKE PROFIT")
@@ -124,29 +143,47 @@ async def _handle(session, rpc, keypair, coin, dry_run, active):
                     total = profits.add(gain)
                     print(f"[bot] Parked +{gain:.4f} SOL (running total: {total:.4f} SOL)", flush=True)
                 break
+
             elif peak_pnl >= config.TRAIL_ACTIVATE_PCT and pnl <= peak_pnl - config.TRAIL_DRAWDOWN_PCT:
-                sol_back = await trader.sell(session, rpc, keypair, trade, f"TRAILING STOP (peak {peak_pnl:+.1f}%)")
+                sol_back = await trader.sell(
+                    session, rpc, keypair, trade, f"TRAILING STOP (peak {peak_pnl:+.1f}%)"
+                )
                 _position_sold = sol_back > 0
                 if config.PARK_PROFITS and sol_back > trade.sol_spent:
                     gain  = sol_back - trade.sol_spent
                     total = profits.add(gain)
                     print(f"[bot] Parked +{gain:.4f} SOL (running total: {total:.4f} SOL)", flush=True)
                 break
-            elif pnl > 0.5 and elapsed >= 20 and time.time() - peak_pnl_time > 30:
-                sol_back = await trader.sell(session, rpc, keypair, trade, "MOMENTUM STALL")
+
+            elif (
+                elapsed >= 15
+                and time.time() - peak_pnl_time > config.MOMENTUM_STALL_PEAK_AGE_SEC
+                and peak_pnl < config.PROFIT_TARGET_PCT
+            ):
+                # No new high in MOMENTUM_STALL_PEAK_AGE_SEC seconds — get out
+                sol_back = await trader.sell(
+                    session, rpc, keypair, trade,
+                    f"MOMENTUM STALL (peak {peak_pnl:+.1f}% {config.MOMENTUM_STALL_PEAK_AGE_SEC}s ago)",
+                )
                 _position_sold = sol_back > 0
                 break
+
             elif pnl <= -dyn_stop:
                 _stop_loss_exit = True
-                sol_back = await trader.sell(session, rpc, keypair, trade, f"STOP LOSS ({dyn_stop:.0f}%)")
+                sol_back = await trader.sell(
+                    session, rpc, keypair, trade, f"STOP LOSS ({dyn_stop:.0f}%)"
+                )
                 _position_sold = sol_back > 0
                 break
+
     finally:
         if _position_sold:
             positions.remove(mint)
         elif trade is not None:
-            # Buy succeeded but all sell attempts failed — keep in positions.json for recovery
-            print(f"[bot] Sell failed for {symbol} — position kept in positions.json for recovery", flush=True)
+            print(
+                f"[bot] Sell failed for {symbol} — position kept in positions.json for recovery",
+                flush=True,
+            )
         active.discard(mint)
         if _stop_loss_exit:
             monitor.block_mint(mint)
@@ -161,7 +198,10 @@ async def main(dry_run: bool) -> None:
         balance_sol  = balance_resp.value / 1_000_000_000
         parked_total = profits.load()
         spendable    = max(0.0, balance_sol - config.GAS_RESERVE_SOL - parked_total)
-        print(f"[bot] Balance={balance_sol:.4f} SOL parked={parked_total:.4f} SOL spendable={spendable:.4f} SOL", flush=True)
+        print(
+            f"[bot] Balance={balance_sol:.4f} SOL parked={parked_total:.4f} SOL spendable={spendable:.4f} SOL",
+            flush=True,
+        )
         if spendable < config.MIN_TRADE_SOL:
             print(f"[bot] !! Too low — fund {kp.pubkey()} then restart", flush=True)
             sys.exit(1)
@@ -169,17 +209,20 @@ async def main(dry_run: bool) -> None:
         rpc = None
         print("[bot] DRY RUN", flush=True)
 
-    print(f"[bot] READY | zone={config.MONITOR_BC_MIN}-{config.MONITOR_BC_MAX}% window={config.MOMENTUM_WINDOW_SEC}s stop={config.STOP_LOSS_PCT}%", flush=True)
+    print(
+        f"[bot] READY | zone={config.MONITOR_BC_MIN}-{config.MONITOR_BC_MAX}% "
+        f"window={config.MOMENTUM_WINDOW_SEC}s stop={config.STOP_LOSS_PCT}%",
+        flush=True,
+    )
 
-    queue        = asyncio.Queue()
-    seen_mints:  set = set()
+    queue         = asyncio.Queue()
+    seen_mints:   set = set()
     active_mints: set = set()
 
     mt = asyncio.create_task(monitor.run(queue, seen_mints), name="monitor")
     mt.add_done_callback(_task_error_handler)
 
     async with aiohttp.ClientSession() as session:
-        # Recover any positions that survived a restart
         orphans = positions.load_open()
         if orphans:
             print(f"[bot] Recovering {len(orphans)} position(s) from previous run", flush=True)
@@ -190,9 +233,10 @@ async def main(dry_run: bool) -> None:
             seen_mints.add(p["mint"])
             task = asyncio.create_task(
                 _monitor_existing(session, rpc, kp, t, active_mints),
-                name=f"recover-{p['mint'][:8]}"
+                name=f"recover-{p['mint'][:8]}",
             )
             task.add_done_callback(_task_error_handler)
+
         try:
             while True:
                 try:
@@ -200,11 +244,16 @@ async def main(dry_run: bool) -> None:
                 except asyncio.TimeoutError:
                     print("[bot] heartbeat — watching...", flush=True)
                     continue
+
                 mint = coin.get("mint")
                 if mint and mint not in active_mints:
                     active_mints.add(mint)
-                    t = asyncio.create_task(_handle(session, rpc, kp, coin, dry_run, active_mints), name=f"handle-{mint[:8]}")
+                    t = asyncio.create_task(
+                        _handle(session, rpc, kp, coin, dry_run, active_mints),
+                        name=f"handle-{mint[:8]}",
+                    )
                     t.add_done_callback(_task_error_handler)
+
         except (KeyboardInterrupt, asyncio.CancelledError):
             pass
         finally:

--- a/bot.py
+++ b/bot.py
@@ -52,6 +52,7 @@ async def _handle(session, rpc, keypair, coin, dry_run, active):
     trade           = None   # set only after a successful buy
     _position_sold  = False
     _stop_loss_exit = False
+    _partial_sold   = False
     try:
         ok, reason = await filters.passes_all(session, rpc, coin)
         if not ok:
@@ -106,6 +107,14 @@ async def _handle(session, rpc, keypair, coin, dry_run, active):
 
             # Dynamic stop: full -5% for first 30s, tightens to -3% after
             dyn_stop = config.STOP_LOSS_PCT if elapsed < 30 else max(3.0, config.STOP_LOSS_PCT * 0.6)
+
+            if not _partial_sold and pnl >= 10.0:
+                sol_back = await trader.sell_partial(session, rpc, keypair, trade, 50)
+                if sol_back > 0:
+                    _partial_sold = True
+                    trade.token_amount //= 2
+                    trade.sol_spent = 0.0  # remainder is house money
+                    print(f"[bot] Partial sell 50% {symbol} — remainder is house money", flush=True)
 
             if pnl >= config.PROFIT_TARGET_PCT:
                 sol_back = await trader.sell(session, rpc, keypair, trade, "TAKE PROFIT")

--- a/config.py
+++ b/config.py
@@ -3,29 +3,36 @@ import os
 RPC_URL = os.environ.get("SOLANA_RPC_URL", "https://api.mainnet-beta.solana.com")
 KEYPAIR_PATH = "./keypair.json"
 
-TRADE_PCT       = float(os.environ.get("TRADE_PCT", "0.15"))
+TRADE_PCT = float(os.environ.get("TRADE_PCT", "0.15"))
 GAS_RESERVE_SOL = float(os.environ.get("GAS_RESERVE_SOL", "0.01"))
-MAX_TRADE_SOL   = float(os.environ.get("MAX_TRADE_SOL", "0.05"))
-MIN_TRADE_SOL   = 0.015
+MAX_TRADE_SOL = float(os.environ.get("MAX_TRADE_SOL", "0.05"))
+MIN_TRADE_SOL = 0.015
 
-MONITOR_BC_MIN      = 1
-MONITOR_BC_MAX      = 88
+# Near-graduation zone only. Coins here have real liquidity and real momentum.
+# 1% was watching the entire curve — mostly noise with no graduation pressure.
+MONITOR_BC_MIN = 65
+MONITOR_BC_MAX = 88
+
 MOMENTUM_WINDOW_SEC = 15
-MIN_BC_RISE_PCT     = 1.0
+MIN_BC_RISE_PCT = 1.0
+MAX_BC_RISE_PCT = 20.0  # reject coordinated pump signals
 
 PROFIT_TARGET_PCT = 8
-STOP_LOSS_PCT     = 5
-MAX_HOLD_SECONDS  = 90
+STOP_LOSS_PCT = 5
+MAX_HOLD_SECONDS = 90
 
 TRAIL_ACTIVATE_PCT = 5
-TRAIL_DRAWDOWN_PCT = 5
+TRAIL_DRAWDOWN_PCT = 3  # tightened from 5 — don't give back that much off peak
 
-POLL_INTERVAL_SEC    = 2.0   # monitor fetch interval
-POSITION_POLL_SEC    = 0.5   # position P&L check interval (faster to catch rugs)
-MAX_BC_RISE_PCT      = 20.0  # reject signals with extreme pumps (likely coordinated rug setup)
+POLL_INTERVAL_SEC = 2.0
+POSITION_POLL_SEC = 0.5
 
 SLIPPAGE_BPS = 2000
-PRIORITY_FEE = "auto"
+
+# Priority fee in lamports (integer). "auto" is not a valid Jupiter parameter.
+# 0.001 SOL = 1_000_000 lamports. Use this everywhere.
+PRIORITY_FEE_LAMPORTS = int(os.environ.get("PRIORITY_FEE_LAMPORTS", "1000000"))
+
 GAS_COST_ROUNDTRIP_SOL = float(os.environ.get("GAS_COST_ROUNDTRIP_SOL", "0.002"))
 
 SOL_MINT  = "So11111111111111111111111111111111111111112"
@@ -37,3 +44,8 @@ MAX_CREATOR_COINS   = 4
 MIN_REPLY_COUNT     = 1
 MIN_AGE_SECONDS     = 5
 COPY_SIMILARITY_PCT = 80
+
+# Momentum stall: exit if peak P&L hasn't been refreshed in this many seconds
+# regardless of whether we're in profit. Sitting on a dead position bleeds gas
+# and blocks capital. Reduced from the implicit ~30s to 20s.
+MOMENTUM_STALL_PEAK_AGE_SEC = 20

--- a/filters.py
+++ b/filters.py
@@ -2,6 +2,7 @@ import time
 from typing import Optional
 
 from solana.rpc.async_api import AsyncClient
+from solders.pubkey import Pubkey
 
 import aiohttp
 import config
@@ -58,6 +59,23 @@ def _is_clone(name: str, symbol: str) -> tuple[bool, str]:
     return False, ""
 
 
+async def _check_holder_safety(rpc: AsyncClient, mint: str, coin: dict) -> tuple[bool, str]:
+    """Return (safe, reason). Rejects coins where top wallets hold >50% of supply."""
+    try:
+        resp = await rpc.get_token_largest_accounts(Pubkey.from_string(mint))
+        if not resp.value:
+            return True, ""
+        accounts = resp.value[:10]
+        total_supply = float(coin.get("total_supply") or 1_000_000_000)
+        top3 = sum(float(a.amount.ui_amount or 0) for a in accounts[:3])
+        top3_pct = top3 / total_supply * 100
+        if top3_pct > 50:
+            return False, f"top3 hold {top3_pct:.0f}%"
+        return True, ""
+    except Exception:
+        return True, ""  # allow on RPC error — don't block trades due to infra issues
+
+
 async def passes_all(session: aiohttp.ClientSession, rpc: Optional[AsyncClient], coin: dict) -> tuple[bool, str]:
     symbol = coin.get("symbol", "?")
     name   = coin.get("name", "?")
@@ -76,5 +94,13 @@ async def passes_all(session: aiohttp.ClientSession, rpc: Optional[AsyncClient],
     if replies < config.MIN_REPLY_COUNT:
         print(f"[filters] SKIP {symbol}: low engagement", flush=True)
         return False, "low engagement"
+
+    if rpc:
+        mint = coin.get("mint", "")
+        if mint:
+            safe, reason = await _check_holder_safety(rpc, mint, coin)
+            if not safe:
+                print(f"[filters] SKIP {symbol}: holder concentration ({reason})", flush=True)
+                return False, reason
 
     return True, ""

--- a/trader.py
+++ b/trader.py
@@ -1,4 +1,5 @@
 import asyncio
+import base58
 import time
 from typing import Optional
 
@@ -10,10 +11,31 @@ from solana.rpc.types import TxOpts
 
 import config
 
-PUMPPORTAL  = "https://pumpportal.fun/api/trade-local"
+PUMPPORTAL    = "https://pumpportal.fun/api/trade-local"
 JUPITER_QUOTE = "https://lite-api.jup.ag/swap/v1/quote"
 JUPITER_SWAP  = "https://lite-api.jup.ag/swap/v1/swap"
 LAMPORTS      = 1_000_000_000
+
+JITO_ENDPOINT = "https://mainnet.block-engine.jito.labs.io/api/v1/transactions"
+
+
+# ── Jito block engine (parallel fast-lane submission) ─────────────────────────
+
+async def _jito_send(session: aiohttp.ClientSession, signed_tx_bytes: bytes) -> Optional[str]:
+    """Submit a signed transaction to Jito's block engine for priority inclusion."""
+    encoded = base58.b58encode(signed_tx_bytes).decode()
+    body = {"jsonrpc": "2.0", "id": 1, "method": "sendTransaction",
+            "params": [encoded, {"encoding": "base58"}]}
+    try:
+        async with session.post(
+            JITO_ENDPOINT, json=body, timeout=aiohttp.ClientTimeout(total=10)
+        ) as resp:
+            if resp.status == 200:
+                data = await resp.json()
+                return data.get("result")
+    except Exception as e:
+        print(f"[trader] Jito send error: {e}", flush=True)
+    return None
 
 
 # ── PumpPortal (primary) ───────────────────────────────────────────────────────
@@ -51,11 +73,28 @@ async def _pumpportal_tx(
 
         tx        = VersionedTransaction.from_bytes(tx_bytes)
         signed_tx = VersionedTransaction(tx.message, [keypair])
-        result    = await rpc.send_raw_transaction(
-            bytes(signed_tx),
+        tx_bytes_signed = bytes(signed_tx)
+
+        # Submit to standard RPC and Jito in parallel; first success wins
+        rpc_coro  = rpc.send_raw_transaction(
+            tx_bytes_signed,
             opts=TxOpts(skip_preflight=True, preflight_commitment="confirmed"),
         )
-        return str(result.value)
+        jito_coro = _jito_send(session, tx_bytes_signed)
+        rpc_task  = asyncio.create_task(rpc_coro)
+        jito_task = asyncio.create_task(jito_coro)
+
+        done, pending = await asyncio.wait(
+            [rpc_task, jito_task], return_when=asyncio.FIRST_COMPLETED
+        )
+        for t in pending:
+            t.cancel()
+
+        result = done.pop().result()
+        if result is None:
+            return None
+        # rpc returns a RpcResponse object; jito returns a string sig directly
+        return str(result.value) if hasattr(result, "value") else str(result)
     except Exception as e:
         print(f"[trader] PumpPortal error: {e}", flush=True)
         return None
@@ -201,6 +240,24 @@ async def buy(
 
     print(f"[trader] Bought {symbol}: {sig}", flush=True)
     return Trade(mint, symbol, token_out, amount_sol)
+
+
+async def sell_partial(
+    session:    aiohttp.ClientSession,
+    rpc:        AsyncClient,
+    keypair:    Keypair,
+    trade:      "Trade",
+    pct:        int,
+) -> float:
+    """Sell a percentage of the position. Returns estimated SOL received."""
+    sig = await _pumpportal_tx(
+        session, rpc, keypair, "sell", trade.mint, f"{pct}%", denom_sol=False
+    )
+    if sig:
+        print(f"[trader] Partial sell {pct}% {trade.symbol}: {sig}", flush=True)
+        value = await current_value_sol(session, trade)
+        return (value or 0.0) * pct / 100
+    return 0.0
 
 
 async def sell(

--- a/trader.py
+++ b/trader.py
@@ -1,5 +1,4 @@
 import asyncio
-import base58
 import time
 from typing import Optional
 
@@ -16,36 +15,15 @@ JUPITER_QUOTE = "https://lite-api.jup.ag/swap/v1/quote"
 JUPITER_SWAP  = "https://lite-api.jup.ag/swap/v1/swap"
 LAMPORTS      = 1_000_000_000
 
-JITO_ENDPOINT = "https://mainnet.block-engine.jito.labs.io/api/v1/transactions"
-
-
-# ── Jito block engine (parallel fast-lane submission) ─────────────────────────
-
-async def _jito_send(session: aiohttp.ClientSession, signed_tx_bytes: bytes) -> Optional[str]:
-    """Submit a signed transaction to Jito's block engine for priority inclusion."""
-    encoded = base58.b58encode(signed_tx_bytes).decode()
-    body = {"jsonrpc": "2.0", "id": 1, "method": "sendTransaction",
-            "params": [encoded, {"encoding": "base58"}]}
-    try:
-        async with session.post(
-            JITO_ENDPOINT, json=body, timeout=aiohttp.ClientTimeout(total=10)
-        ) as resp:
-            if resp.status == 200:
-                data = await resp.json()
-                return data.get("result")
-    except Exception as e:
-        print(f"[trader] Jito send error: {e}", flush=True)
-    return None
-
 
 # ── PumpPortal (primary) ───────────────────────────────────────────────────────
 
 async def _pumpportal_tx(
-    session:  aiohttp.ClientSession,
-    rpc:      AsyncClient,
-    keypair:  Keypair,
-    action:   str,
-    mint:     str,
+    session:   aiohttp.ClientSession,
+    rpc:       AsyncClient,
+    keypair:   Keypair,
+    action:    str,
+    mint:      str,
     amount,
     denom_sol: bool,
 ) -> Optional[str]:
@@ -56,7 +34,7 @@ async def _pumpportal_tx(
         "denominatedInSol": "true" if denom_sol else "false",
         "amount":           amount,
         "slippage":         15,
-        "priorityFee":      0.001,
+        "priorityFee":      config.PRIORITY_FEE_LAMPORTS / LAMPORTS,  # PumpPortal takes SOL float
         "pool":             "pump",
     }
     try:
@@ -73,28 +51,11 @@ async def _pumpportal_tx(
 
         tx        = VersionedTransaction.from_bytes(tx_bytes)
         signed_tx = VersionedTransaction(tx.message, [keypair])
-        tx_bytes_signed = bytes(signed_tx)
-
-        # Submit to standard RPC and Jito in parallel; first success wins
-        rpc_coro  = rpc.send_raw_transaction(
-            tx_bytes_signed,
+        result    = await rpc.send_raw_transaction(
+            bytes(signed_tx),
             opts=TxOpts(skip_preflight=True, preflight_commitment="confirmed"),
         )
-        jito_coro = _jito_send(session, tx_bytes_signed)
-        rpc_task  = asyncio.create_task(rpc_coro)
-        jito_task = asyncio.create_task(jito_coro)
-
-        done, pending = await asyncio.wait(
-            [rpc_task, jito_task], return_when=asyncio.FIRST_COMPLETED
-        )
-        for t in pending:
-            t.cancel()
-
-        result = done.pop().result()
-        if result is None:
-            return None
-        # rpc returns a RpcResponse object; jito returns a string sig directly
-        return str(result.value) if hasattr(result, "value") else str(result)
+        return str(result.value)
     except Exception as e:
         print(f"[trader] PumpPortal error: {e}", flush=True)
         return None
@@ -118,19 +79,22 @@ async def _jupiter_quote(session, input_mint, output_mint, amount):
         return None
 
 
-async def _jupiter_swap(session, rpc, keypair, quote):
+async def _jupiter_swap(session, rpc, keypair, quote) -> Optional[float]:
+    """Execute Jupiter swap. Returns SOL received on success, None on failure."""
     import base64
     body = {
         "quoteResponse":             quote,
         "userPublicKey":             str(keypair.pubkey()),
         "wrapAndUnwrapSol":          True,
-        "prioritizationFeeLamports": config.PRIORITY_FEE,
+        "prioritizationFeeLamports": config.PRIORITY_FEE_LAMPORTS,
     }
     try:
         async with session.post(
             JUPITER_SWAP, json=body, timeout=aiohttp.ClientTimeout(total=15)
         ) as resp:
             if resp.status != 200:
+                err = await resp.text()
+                print(f"[trader] Jupiter swap {resp.status}: {err[:200]}", flush=True)
                 return None
             data = await resp.json()
         tx_bytes  = base64.b64decode(data["swapTransaction"])
@@ -140,7 +104,8 @@ async def _jupiter_swap(session, rpc, keypair, quote):
             bytes(signed_tx),
             opts=TxOpts(skip_preflight=True, preflight_commitment="confirmed"),
         )
-        return str(result.value)
+        print(f"[trader] Jupiter tx submitted: {result.value}", flush=True)
+        return int(quote.get("outAmount", 0)) / LAMPORTS
     except Exception as e:
         print(f"[trader] Jupiter error: {e}", flush=True)
         return None
@@ -152,9 +117,10 @@ class Trade:
     def __init__(self, mint: str, symbol: str, token_amount: int, sol_spent: float):
         self.mint         = mint
         self.symbol       = symbol
-        self.token_amount = token_amount  # raw units, kept for Jupiter fallback
+        self.token_amount = token_amount
         self.sol_spent    = sol_spent
         self._entry_time  = time.time()
+        self._half_sold   = False  # tracks whether the 50% house-money sell has fired
 
     def elapsed(self) -> float:
         return time.time() - self._entry_time
@@ -194,7 +160,17 @@ async def current_value_sol(session: aiohttp.ClientSession, trade: Trade) -> Opt
     return None
 
 
-# ── Buy / Sell ────────────────────────────────────────────────────────────────
+# ── Balance helper ────────────────────────────────────────────────────────────
+
+async def _get_sol_balance(rpc: AsyncClient, keypair: Keypair) -> float:
+    try:
+        resp = await rpc.get_balance(keypair.pubkey())
+        return resp.value / LAMPORTS
+    except Exception:
+        return 0.0
+
+
+# ── Buy ────────────────────────────────────────────────────────────────────────
 
 async def buy(
     session:    aiohttp.ClientSession,
@@ -205,60 +181,44 @@ async def buy(
     amount_sol: float,
 ) -> Optional[Trade]:
     print(f"[trader] Buying {symbol} via PumpPortal: {amount_sol:.4f} SOL", flush=True)
+
+    # Estimate token output from bonding curve before the buy
+    token_out = 0
+    try:
+        async with session.get(
+            f"https://frontend-api-v3.pump.fun/coins/{mint}",
+            timeout=aiohttp.ClientTimeout(total=5),
+        ) as resp:
+            if resp.status == 200:
+                coin = await resp.json(content_type=None)
+                vsol = coin.get("virtual_sol_reserves") or 1
+                vtok = coin.get("virtual_token_reserves") or 1
+                amount_lamports = int(amount_sol * LAMPORTS)
+                token_out = int(vtok * amount_lamports / (vsol + amount_lamports))
+    except Exception:
+        pass
+
     sig = await _pumpportal_tx(session, rpc, keypair, "buy", mint, amount_sol, denom_sol=True)
 
     if not sig:
-        # Fallback: Jupiter
         print(f"[trader] PumpPortal buy failed, trying Jupiter…", flush=True)
         lamports = int(amount_sol * LAMPORTS)
         quote    = await _jupiter_quote(session, config.SOL_MINT, mint, lamports)
         if quote:
-            sig = await _jupiter_swap(session, rpc, keypair, quote)
-            token_out = int(quote.get("outAmount", 0))
-        else:
-            token_out = 0
-    else:
-        # Estimate token amount from curve for tracking
-        dummy = Trade(mint, symbol, 0, amount_sol)
-        val   = await _pumpfun_value_sol(session, dummy)
-        # Approximate raw token amount from reserves
-        try:
-            async with session.get(
-                f"https://frontend-api-v3.pump.fun/coins/{mint}",
-                timeout=aiohttp.ClientTimeout(total=5),
-            ) as resp:
-                coin = await resp.json(content_type=None) if resp.status == 200 else {}
-            vsol = coin.get("virtual_sol_reserves") or 1
-            vtok = coin.get("virtual_token_reserves") or 1
-            token_out = int((amount_sol * LAMPORTS) / vsol * vtok)
-        except Exception:
-            token_out = 0
+            sol_out = await _jupiter_swap(session, rpc, keypair, quote)
+            if sol_out is not None:
+                token_out = int(quote.get("outAmount", 0))
+                sig = "jupiter"
 
-    if not sig:
+    if not sig or (sig == "jupiter" and token_out == 0):
         print(f"[trader] Buy failed for {symbol}", flush=True)
         return None
 
-    print(f"[trader] Bought {symbol}: {sig}", flush=True)
+    print(f"[trader] Bought {symbol}: {sig} | est_tokens={token_out}", flush=True)
     return Trade(mint, symbol, token_out, amount_sol)
 
 
-async def sell_partial(
-    session:    aiohttp.ClientSession,
-    rpc:        AsyncClient,
-    keypair:    Keypair,
-    trade:      "Trade",
-    pct:        int,
-) -> float:
-    """Sell a percentage of the position. Returns estimated SOL received."""
-    sig = await _pumpportal_tx(
-        session, rpc, keypair, "sell", trade.mint, f"{pct}%", denom_sol=False
-    )
-    if sig:
-        print(f"[trader] Partial sell {pct}% {trade.symbol}: {sig}", flush=True)
-        value = await current_value_sol(session, trade)
-        return (value or 0.0) * pct / 100
-    return 0.0
-
+# ── Sell ───────────────────────────────────────────────────────────────────────
 
 async def sell(
     session: aiohttp.ClientSession,
@@ -267,32 +227,104 @@ async def sell(
     trade:   Trade,
     reason:  str,
 ) -> float:
-    """Sell with up to 3 attempts. Returns SOL received."""
-    # Get current value for logging
+    """Sell with up to 3 attempts. Returns SOL received (measured via balance delta)."""
     value = await current_value_sol(session, trade)
     pnl   = trade.pnl_pct(value) if value else 0
-    print(f"[trader] Selling {trade.symbol} [{reason}] | est {value:.4f} SOL | P&L {pnl:+.1f}%", flush=True)
+    print(
+        f"[trader] Selling {trade.symbol} [{reason}] | est {value:.4f} SOL | P&L {pnl:+.1f}%",
+        flush=True,
+    )
+
+    bal_before = await _get_sol_balance(rpc, keypair)
 
     for attempt in range(1, 4):
-        # PumpPortal: sell 100% of position
         sig = await _pumpportal_tx(
             session, rpc, keypair, "sell", trade.mint, "100%", denom_sol=False
         )
         if sig:
-            print(f"[trader] Sold {trade.symbol}: {sig}", flush=True)
-            return value or 0.0
+            await asyncio.sleep(2)
+            bal_after    = await _get_sol_balance(rpc, keypair)
+            sol_received = bal_after - bal_before + config.GAS_COST_ROUNDTRIP_SOL / 2
+            if sol_received > 0.001:
+                print(
+                    f"[trader] Sold {trade.symbol}: {sig} | received {sol_received:.4f} SOL",
+                    flush=True,
+                )
+                return sol_received
+            print(
+                f"[trader] Sig returned but balance unchanged (attempt {attempt}) — retrying",
+                flush=True,
+            )
+            bal_before = bal_after
 
-        print(f"[trader] PumpPortal sell failed (attempt {attempt}), trying Jupiter…", flush=True)
-        # Jupiter fallback
+        print(f"[trader] PumpPortal sell attempt {attempt} failed, trying Jupiter…", flush=True)
         quote = await _jupiter_quote(session, trade.mint, config.SOL_MINT, trade.token_amount)
         if quote:
-            sig = await _jupiter_swap(session, rpc, keypair, quote)
-            if sig:
-                sol_out = int(quote.get("outAmount", 0)) / LAMPORTS
-                print(f"[trader] Sold {trade.symbol} via Jupiter: {sig}", flush=True)
+            sol_out = await _jupiter_swap(session, rpc, keypair, quote)
+            if sol_out is not None and sol_out > 0.001:
+                print(f"[trader] Sold {trade.symbol} via Jupiter: {sol_out:.4f} SOL", flush=True)
                 return sol_out
 
         await asyncio.sleep(2)
 
     print(f"[trader] GAVE UP selling {trade.symbol} after 3 attempts", flush=True)
+    return 0.0
+
+
+# ── Partial sell (house money) ─────────────────────────────────────────────────
+
+async def sell_partial(
+    session:  aiohttp.ClientSession,
+    rpc:      AsyncClient,
+    keypair:  Keypair,
+    trade:    Trade,
+    pct:      float,
+    reason:   str,
+) -> float:
+    """
+    Sell `pct` fraction of the position (0.0–1.0). Updates trade.token_amount in place.
+    Returns SOL received.
+    """
+    tokens_to_sell = int(trade.token_amount * pct)
+    if tokens_to_sell == 0:
+        return 0.0
+
+    value = await current_value_sol(session, trade)
+    print(
+        f"[trader] Partial sell {trade.symbol} {pct*100:.0f}% [{reason}] "
+        f"| full est {value:.4f} SOL",
+        flush=True,
+    )
+
+    bal_before = await _get_sol_balance(rpc, keypair)
+
+    sig = await _pumpportal_tx(
+        session, rpc, keypair, "sell", trade.mint, tokens_to_sell, denom_sol=False
+    )
+    if sig:
+        await asyncio.sleep(2)
+        bal_after    = await _get_sol_balance(rpc, keypair)
+        sol_received = bal_after - bal_before + config.GAS_COST_ROUNDTRIP_SOL / 4
+        if sol_received > 0.001:
+            trade.token_amount -= tokens_to_sell
+            print(
+                f"[trader] Partial sold {trade.symbol}: {sol_received:.4f} SOL "
+                f"| remaining tokens: {trade.token_amount}",
+                flush=True,
+            )
+            return sol_received
+
+    # Fallback: Jupiter partial
+    quote = await _jupiter_quote(session, trade.mint, config.SOL_MINT, tokens_to_sell)
+    if quote:
+        sol_out = await _jupiter_swap(session, rpc, keypair, quote)
+        if sol_out is not None and sol_out > 0.001:
+            trade.token_amount -= tokens_to_sell
+            print(
+                f"[trader] Partial sold {trade.symbol} via Jupiter: {sol_out:.4f} SOL",
+                flush=True,
+            )
+            return sol_out
+
+    print(f"[trader] Partial sell failed for {trade.symbol}", flush=True)
     return 0.0


### PR DESCRIPTION
## Changes

**config.py**
- `MONITOR_BC_MIN` raised to 65 — only near-graduation coins, no more early-stage noise
- `TRAIL_DRAWDOWN_PCT` tightened to 3 (was 5)
- `PRIORITY_FEE_LAMPORTS` replaces `"auto"` string — fixes Jupiter crash
- `MOMENTUM_STALL_PEAK_AGE_SEC = 20` configurable

**trader.py**
- Sell confirmation via balance delta — verifies the transaction actually landed, not just that a signature was returned
- `sell_partial` for percentage exits with balance confirmation
- `_half_sold` flag on Trade for house-money tracking
- `PRIORITY_FEE_LAMPORTS` used consistently for PumpPortal and Jupiter

**bot.py**
- House money: sell 50% at +10%, continue trailing the rest from zero cost basis
- Momentum stall now exits losing positions too (old code required pnl > 0.5)
- Uses `MOMENTUM_STALL_PEAK_AGE_SEC` from config