### PR TITLE
Add minProgress=65 API pre-filter to monitor

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -68,6 +68,7 @@ async def _fetch_zone(session: aiohttp.ClientSession) -> list[dict]:
         "order":       "DESC",
         "limit":       100,
         "includeNsfw": "true",
+        "minProgress": 65,   # API-level pre-filter; silently ignored if unsupported
     }
     try:
         async with session.get(


### PR DESCRIPTION
Passes `minProgress=65` to the pump.fun coins API so the server pre-filters to near-graduation coins before they even reach the BC check in code.

- If the param is supported: API returns only 65–88% coins, more signal per request
- If the param is unsupported: silently ignored, existing code-level BC filter still applies, nothing breaks

Kept `limit=100` and `sortBy=last_trade_timestamp` — reducing limit or switching sort would hurt momentum coverage.