### PR TITLE
Fix zero-signal bug: sort by bondingCurve, lower BC min to 30

### DIFF
--- a/config.py
+++ b/config.py
@@ -10,7 +10,7 @@ MIN_TRADE_SOL = 0.015
 
 # Near-graduation zone only. Coins here have real liquidity and real momentum.
 # 1% was watching the entire curve — mostly noise with no graduation pressure.
-MONITOR_BC_MIN = 65
+MONITOR_BC_MIN = 30
 MONITOR_BC_MAX = 88
 
 MOMENTUM_WINDOW_SEC = 15

--- a/monitor.py
+++ b/monitor.py
@@ -64,11 +64,10 @@ async def _fetch_zone(session: aiohttp.ClientSession) -> list[dict]:
     """Fetch coins sorted by bonding curve progress descending (near graduation first)."""
     global _err_count
     params = {
-        "sortBy":      "last_trade_timestamp",
+        "sortBy":      "bondingCurve",
         "order":       "DESC",
         "limit":       100,
         "includeNsfw": "true",
-        "minProgress": 65,   # API-level pre-filter; silently ignored if unsupported
     }
     try:
         async with session.get(


### PR DESCRIPTION
The bot was seeing 0 qualifying coins because `MONITOR_BC_MIN=65` but the API only returned coins at 0–27% BC.

Two fixes:
- `sortBy=bondingCurve` DESC to pull highest-progress coins to the top of results
- `MONITOR_BC_MIN=30` as safety net in case bondingCurve sort is also unsupported by the API

If bondingCurve sort works: logs will show BC range shifting up toward 65%+. If not: bot will still trade on 30–88% coins instead of seeing nothing.