### PR TITLE
Tighten entry filters: max pump 15pts, holder threshold 40%

### DIFF
--- a/config.py
+++ b/config.py
@@ -15,7 +15,7 @@ MONITOR_BC_MAX = 88
 
 MOMENTUM_WINDOW_SEC = 15
 MIN_BC_RISE_PCT = 1.0
-MAX_BC_RISE_PCT = 20.0  # reject coordinated pump signals
+MAX_BC_RISE_PCT = 15.0  # reject coordinated pump signals
 
 PROFIT_TARGET_PCT = 8
 STOP_LOSS_PCT = 5

--- a/filters.py
+++ b/filters.py
@@ -69,7 +69,7 @@ async def _check_holder_safety(rpc: AsyncClient, mint: str, coin: dict) -> tuple
         total_supply = float(coin.get("total_supply") or 1_000_000_000)
         top3 = sum(float(a.amount.ui_amount or 0) for a in accounts[:3])
         top3_pct = top3 / total_supply * 100
-        if top3_pct > 50:
+        if top3_pct > 40:
             return False, f"top3 hold {top3_pct:.0f}%"
         return True, ""
     except Exception:


### PR DESCRIPTION
GROKIPEDIA rugged at held=1s. Tightening two filters to reduce these entries:

- `MAX_BC_RISE_PCT` 20 → 15: rejects slightly faster pumps
- Holder concentration threshold 50% → 40%: blocks more top-heavy distributions before buying