### PR TITLE
Fix Jupiter sell silently failing + tighten all filters/exits

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -135,8 +135,8 @@ async def _handle(session, rpc, keypair, coin, dry_run, active):
                 # Continue managing the remaining 50%
                 continue
 
-            # Dynamic stop: full -5% for first 30s, tightens to -3% after
-            dyn_stop = config.STOP_LOSS_PCT if elapsed < 30 else max(3.0, config.STOP_LOSS_PCT * 0.6)
+            # Dynamic stop: full stop for first 15s, tightens to 3% after
+            dyn_stop = config.STOP_LOSS_PCT if elapsed < 15 else 3.0
 
             if pnl >= config.PROFIT_TARGET_PCT:
                 sol_back = await trader.sell(session, rpc, keypair, trade, "TAKE PROFIT")

--- a/config.py
+++ b/config.py
@@ -10,7 +10,7 @@ MIN_TRADE_SOL = 0.015
 
 # Near-graduation zone only. Coins here have real liquidity and real momentum.
 # 1% was watching the entire curve — mostly noise with no graduation pressure.
-MONITOR_BC_MIN = 30
+MONITOR_BC_MIN = 50        # raised from 30 — real momentum + exit liquidity starts here
 MONITOR_BC_MAX = 88
 
 MOMENTUM_WINDOW_SEC = 15
@@ -18,11 +18,11 @@ MIN_BC_RISE_PCT = 3.0
 MAX_BC_RISE_PCT = 15.0  # reject coordinated pump signals
 
 PROFIT_TARGET_PCT = 8
-STOP_LOSS_PCT = 5
-MAX_HOLD_SECONDS = 90
+STOP_LOSS_PCT = 4          # tightened from 5 — cut losses faster
+MAX_HOLD_SECONDS = 60      # reduced from 90 — dead coins don't recover
 
 TRAIL_ACTIVATE_PCT = 5
-TRAIL_DRAWDOWN_PCT = 3  # tightened from 5 — don't give back that much off peak
+TRAIL_DRAWDOWN_PCT = 2     # tightened from 3 — don't give back gains
 
 POLL_INTERVAL_SEC = 2.0
 POSITION_POLL_SEC = 0.5
@@ -41,11 +41,9 @@ USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
 PARK_PROFITS = True
 
 MAX_CREATOR_COINS   = 4
-MIN_REPLY_COUNT     = 1
-MIN_AGE_SECONDS     = 5
-COPY_SIMILARITY_PCT = 80
+MIN_REPLY_COUNT     = 3    # raised from 1 — require actual engagement
+MIN_AGE_SECONDS     = 30   # raised from 5 — dev dump window is first 30s
+COPY_SIMILARITY_PCT = 70   # lowered from 80 — catch more clone variants
 
 # Momentum stall: exit if peak P&L hasn't been refreshed in this many seconds
-# regardless of whether we're in profit. Sitting on a dead position bleeds gas
-# and blocks capital. Reduced from the implicit ~30s to 20s.
-MOMENTUM_STALL_PEAK_AGE_SEC = 20
+MOMENTUM_STALL_PEAK_AGE_SEC = 10  # reduced from 20 — exit dead coins faster

--- a/filters.py
+++ b/filters.py
@@ -76,9 +76,21 @@ async def _check_holder_safety(rpc: AsyncClient, mint: str, coin: dict) -> tuple
         return True, ""  # allow on RPC error — don't block trades due to infra issues
 
 
+def _is_non_ascii(name: str, symbol: str) -> bool:
+    """Reject coins with Korean/Chinese/Japanese/Cyrillic characters — nearly always rugs."""
+    for ch in name + symbol:
+        if ord(ch) > 127:
+            return True
+    return False
+
+
 async def passes_all(session: aiohttp.ClientSession, rpc: Optional[AsyncClient], coin: dict) -> tuple[bool, str]:
     symbol = coin.get("symbol", "?")
     name   = coin.get("name", "?")
+
+    if _is_non_ascii(name, symbol):
+        print(f"[filters] SKIP {symbol}: non-ASCII name/symbol", flush=True)
+        return False, "non-ascii"
 
     age = _coin_age_seconds(coin)
     if age < config.MIN_AGE_SECONDS:

--- a/trader.py
+++ b/trader.py
@@ -80,7 +80,7 @@ async def _jupiter_quote(session, input_mint, output_mint, amount):
 
 
 async def _jupiter_swap(session, rpc, keypair, quote) -> Optional[float]:
-    """Execute Jupiter swap. Returns SOL received on success, None on failure."""
+    """Execute Jupiter swap. Returns SOL received (balance delta) on success, None on failure."""
     import base64
     body = {
         "quoteResponse":             quote,
@@ -100,12 +100,19 @@ async def _jupiter_swap(session, rpc, keypair, quote) -> Optional[float]:
         tx_bytes  = base64.b64decode(data["swapTransaction"])
         tx        = VersionedTransaction.from_bytes(tx_bytes)
         signed_tx = VersionedTransaction(tx.message, [keypair])
+        bal_before = await _get_sol_balance(rpc, keypair)
         result    = await rpc.send_raw_transaction(
             bytes(signed_tx),
             opts=TxOpts(skip_preflight=True, preflight_commitment="confirmed"),
         )
         print(f"[trader] Jupiter tx submitted: {result.value}", flush=True)
-        return int(quote.get("outAmount", 0)) / LAMPORTS
+        await asyncio.sleep(3)
+        bal_after = await _get_sol_balance(rpc, keypair)
+        sol_received = bal_after - bal_before + config.GAS_COST_ROUNDTRIP_SOL / 2
+        if sol_received > 0.001:
+            return sol_received
+        print(f"[trader] Jupiter tx landed but balance unchanged — tx likely failed", flush=True)
+        return None
     except Exception as e:
         print(f"[trader] Jupiter error: {e}", flush=True)
         return None


### PR DESCRIPTION
**Root cause of every manual sell:** Jupiter was returning the quote's `outAmount` immediately without confirming the tx landed. Failed txs looked like successes — position removed from JSON, tokens stayed in wallet.

Fix: wait 3s after submission, check actual SOL balance delta. Returns None if unchanged so the loop retries.

Also in this PR:
- `MONITOR_BC_MIN` 30→50 (real momentum zone)
- `STOP_LOSS_PCT` 5→4, tightens to 3% after 15s (was 30s)
- `MAX_HOLD_SECONDS` 90→60
- `TRAIL_DRAWDOWN_PCT` 3→2
- `MOMENTUM_STALL_PEAK_AGE_SEC` 20→10
- `MIN_REPLY_COUNT` 1→3
- `MIN_AGE_SECONDS` 5→30 (avoid dev dump window)
- Non-ASCII coin name filter (blocks 환매-style rugs)