### PR TITLE
Loosen and expose signal filters for Railway bot discovery

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -214,7 +214,10 @@ async def main(dry_run: bool) -> None:
 
     print(
         f"[bot] READY | zone={config.MONITOR_BC_MIN}-{config.MONITOR_BC_MAX}% "
-        f"window={config.MOMENTUM_WINDOW_SEC}s stop={config.STOP_LOSS_PCT}%",
+        f"signal={config.MONITOR_CONSECUTIVE_BUYS} buys/{config.MOMENTUM_WINDOW_SEC}s "
+        f"rise={config.MIN_BC_RISE_PCT}-{config.MAX_BC_RISE_PCT}% "
+        f"filters(age>={config.MIN_AGE_SECONDS}s replies>={config.MIN_REPLY_COUNT}) "
+        f"stop={config.STOP_LOSS_PCT}%",
         flush=True,
     )
 

--- a/config.py
+++ b/config.py
@@ -10,12 +10,13 @@ MIN_TRADE_SOL = 0.015
 
 # Near-graduation zone only. Coins here have real liquidity and real momentum.
 # 1% was watching the entire curve — mostly noise with no graduation pressure.
-MONITOR_BC_MIN = 50        # raised from 30 — real momentum + exit liquidity starts here
-MONITOR_BC_MAX = 88
+MONITOR_BC_MIN = float(os.environ.get("MONITOR_BC_MIN", "35"))
+MONITOR_BC_MAX = float(os.environ.get("MONITOR_BC_MAX", "88"))
 
-MOMENTUM_WINDOW_SEC = 15
-MIN_BC_RISE_PCT = 3.0
-MAX_BC_RISE_PCT = 15.0  # reject coordinated pump signals
+MONITOR_CONSECUTIVE_BUYS = int(os.environ.get("MONITOR_CONSECUTIVE_BUYS", "2"))
+MOMENTUM_WINDOW_SEC = int(os.environ.get("MOMENTUM_WINDOW_SEC", "10"))
+MIN_BC_RISE_PCT = float(os.environ.get("MIN_BC_RISE_PCT", "1.5"))
+MAX_BC_RISE_PCT = float(os.environ.get("MAX_BC_RISE_PCT", "15.0"))  # reject coordinated pump signals
 
 PROFIT_TARGET_PCT = 8
 STOP_LOSS_PCT = 4          # tightened from 5 — cut losses faster
@@ -42,9 +43,9 @@ USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
 PARK_PROFITS = False  # let profits compound into larger trade sizes
 
 MAX_CREATOR_COINS   = 4
-MIN_REPLY_COUNT     = 3    # raised from 1 — require actual engagement
-MIN_AGE_SECONDS     = 30   # raised from 5 — dev dump window is first 30s
-COPY_SIMILARITY_PCT = 70   # lowered from 80 — catch more clone variants
+MIN_REPLY_COUNT     = int(os.environ.get("MIN_REPLY_COUNT", "1"))
+MIN_AGE_SECONDS     = int(os.environ.get("MIN_AGE_SECONDS", "15"))
+COPY_SIMILARITY_PCT = int(os.environ.get("COPY_SIMILARITY_PCT", "75"))
 
 # Momentum stall: exit if peak P&L hasn't been refreshed in this many seconds
 MOMENTUM_STALL_PEAK_AGE_SEC = 10  # reduced from 20 — exit dead coins faster

--- a/monitor.py
+++ b/monitor.py
@@ -43,8 +43,8 @@ SIGNAL_COOLDOWN_SEC = 600
 # Permanent session blocks (set after stop-loss exits)
 _permanent_blocks: set = set()
 
-CONSECUTIVE_BUYS = 3   # consecutive buys needed to fire a signal
-TRADE_WINDOW_SEC = 10  # look-back window for consecutive buys
+CONSECUTIVE_BUYS = config.MONITOR_CONSECUTIVE_BUYS
+TRADE_WINDOW_SEC = config.MOMENTUM_WINDOW_SEC
 
 
 def block_mint(mint: str) -> None:
@@ -138,7 +138,9 @@ async def _zone_poller(ws, session: aiohttp.ClientSession) -> None:
         if new:
             await _subscribe(ws, new)
         print(
-            f"[monitor] Zone poll: {len(mints)} in zone, +{len(new)} new ({len(_subscribed)} total)",
+            f"[monitor] Zone poll: {len(mints)} in zone, +{len(new)} new ({len(_subscribed)} total) "
+            f"| zone={config.MONITOR_BC_MIN:.1f}-{config.MONITOR_BC_MAX:.1f}% "
+            f"signal={CONSECUTIVE_BUYS} buys/{TRADE_WINDOW_SEC}s",
             flush=True,
         )
         await asyncio.sleep(5)


### PR DESCRIPTION
### Motivation
- The bot was frequently producing no signals because several discovery filters were hard-coded to strict values, so the change exposes those thresholds as environment-configurable settings and relaxes defaults to surface more candidates. 
- Making the signal parameters configurable enables Railway (or other hosts) to tune discovery in low-traffic environments without changing code. 
- The startup and zone-poll logs were expanded so remote logs clearly show the active filter profile for easier debugging in hosted environments. 

### Description
- Moved several monitor and filter thresholds into `config.py` and allowed them to be set via environment variables, including `MONITOR_BC_MIN`, `MONITOR_BC_MAX`, `MONITOR_CONSECUTIVE_BUYS`, `MOMENTUM_WINDOW_SEC`, `MIN_BC_RISE_PCT`, `MAX_BC_RISE_PCT`, `MIN_REPLY_COUNT`, `MIN_AGE_SECONDS`, and `COPY_SIMILARITY_PCT`. 
- Relaxed sensible defaults (e.g. `MONITOR_BC_MIN` lowered from 50 to 35, consecutive-buys default from 3→2, reply/age minimums lowered) so the bot surfaces more candidates by default. 
- Wired `monitor.py` runtime constants to the new config values (`CONSECUTIVE_BUYS = config.MONITOR_CONSECUTIVE_BUYS` and `TRADE_WINDOW_SEC = config.MOMENTUM_WINDOW_SEC`) and updated zone-poll logging to include the active zone/signal profile. 
- Updated `bot.py` startup message to print the active discovery profile and filter ranges so remote logs show what the monitor is using. 

### Testing
- Ran `python -m py_compile bot.py monitor.py config.py filters.py trader.py wallet.py` and the compilation check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c542a00b0c8321a9a7ae8a5f6fff41)