### PR TITLE
Prune monitor state, respect BONDED_ONLY fallback behavior, and make Jupiter buys more robust

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -32,6 +32,7 @@ _HEADERS = {
 
 # Per-mint buy history: list of (timestamp, bc_pct)
 _buy_history: dict[str, list] = defaultdict(list)
+_buy_last_update: dict[str, float] = {}
 
 # Mints we've already subscribed to trade events
 _subscribed: set = set()
@@ -39,6 +40,7 @@ _subscribed: set = set()
 # Signal cooldown tracking
 _signal_times: dict[str, float] = {}
 SIGNAL_COOLDOWN_SEC = 600
+HISTORY_STALE_SEC = max(60, config.MOMENTUM_WINDOW_SEC * 6)
 
 # Permanent session blocks (set after stop-loss exits)
 _permanent_blocks: set = set()
@@ -69,6 +71,21 @@ async def _enqueue_candidate(
     seen_mints.add(mint)
     _signal_times[mint] = timestamp or time.time()
     await queue.put(coin)
+
+
+def _prune_runtime_state(seen_mints: set, now: float | None = None) -> None:
+    """Prune expired cooldown entries and stale momentum history."""
+    now = now or time.time()
+
+    expired = [m for m, t in list(_signal_times.items()) if now - t > SIGNAL_COOLDOWN_SEC]
+    for mint in expired:
+        seen_mints.discard(mint)
+        del _signal_times[mint]
+
+    stale_history = [m for m, ts in list(_buy_last_update.items()) if now - ts > HISTORY_STALE_SEC]
+    for mint in stale_history:
+        _buy_history.pop(mint, None)
+        del _buy_last_update[mint]
 
 
 def block_mint(mint: str) -> None:
@@ -183,15 +200,18 @@ async def _zone_poller(ws, session: aiohttp.ClientSession, queue: asyncio.Queue,
             await _subscribe(ws, new)
 
         # Fallback path: if WS trade events are sparse/blocked, still process in-zone mints.
+        # In BONDED_ONLY mode we intentionally do not fallback-enqueue from REST, because
+        # that bypasses the WS buy-momentum signal requirements.
         fallback_queued = 0
-        for mint in new:
-            if mint in seen_mints or mint in _permanent_blocks:
-                continue
-            coin = await _fetch_coin(session, mint)
-            if not coin:
-                continue
-            await _enqueue_candidate(queue, seen_mints, mint, coin)
-            fallback_queued += 1
+        if not config.BONDED_ONLY:
+            for mint in new:
+                if mint in seen_mints or mint in _permanent_blocks:
+                    continue
+                coin = await _fetch_coin(session, mint)
+                if not coin:
+                    continue
+                await _enqueue_candidate(queue, seen_mints, mint, coin)
+                fallback_queued += 1
 
         print(
             f"[monitor] Zone poll: {len(mints)} in zone, +{len(new)} new ({len(_subscribed)} total) "
@@ -199,6 +219,7 @@ async def _zone_poller(ws, session: aiohttp.ClientSession, queue: asyncio.Queue,
             f"| {_signal_profile()}",
             flush=True,
         )
+        _prune_runtime_state(seen_mints)
         await asyncio.sleep(5)
 
 
@@ -228,6 +249,7 @@ async def _handle_event(
         now     = time.time()
         history = _buy_history[mint]
         history.append((now, 0.0))
+        _buy_last_update[mint] = now
         cutoff             = now - config.MOMENTUM_WINDOW_SEC
         _buy_history[mint] = [(t, bc) for t, bc in history if t >= cutoff]
         if len(_buy_history[mint]) < config.MONITOR_CONSECUTIVE_BUYS:
@@ -270,6 +292,7 @@ async def _handle_event(
     now     = time.time()
     history = _buy_history[mint]
     history.append((now, bc_pct))
+    _buy_last_update[mint] = now
 
     # Trim to window
     cutoff             = now - config.MOMENTUM_WINDOW_SEC
@@ -320,12 +343,7 @@ async def _run_ws(queue: asyncio.Queue, seen_mints: set) -> None:
                         except json.JSONDecodeError:
                             continue
 
-                        # Expire cooldowns
-                        now     = time.time()
-                        expired = [m for m, t in list(_signal_times.items()) if now - t > SIGNAL_COOLDOWN_SEC]
-                        for m in expired:
-                            seen_mints.discard(m)
-                            del _signal_times[m]
+                        _prune_runtime_state(seen_mints)
 
                         await _handle_event(event, ws, session, queue, seen_mints)
 

--- a/trader.py
+++ b/trader.py
@@ -80,8 +80,8 @@ async def _jupiter_quote(session, input_mint, output_mint, amount, slippage_bps:
         return None
 
 
-async def _jupiter_swap(session, rpc, keypair, quote) -> Optional[float]:
-    """Execute Jupiter swap. Returns SOL received (balance delta) on success, None on failure."""
+async def _jupiter_swap(session, rpc, keypair, quote) -> Optional[str]:
+    """Execute Jupiter swap tx and return signature on success."""
     import base64
     body = {
         "quoteResponse":             quote,
@@ -101,19 +101,13 @@ async def _jupiter_swap(session, rpc, keypair, quote) -> Optional[float]:
         tx_bytes  = base64.b64decode(data["swapTransaction"])
         tx        = VersionedTransaction.from_bytes(tx_bytes)
         signed_tx = VersionedTransaction(tx.message, [keypair])
-        bal_before = await _get_sol_balance(rpc, keypair)
         result    = await rpc.send_raw_transaction(
             bytes(signed_tx),
             opts=TxOpts(skip_preflight=True, preflight_commitment="confirmed"),
         )
-        print(f"[trader] Jupiter tx submitted: {result.value}", flush=True)
-        await asyncio.sleep(3)
-        bal_after = await _get_sol_balance(rpc, keypair)
-        sol_received = bal_after - bal_before + config.GAS_COST_ROUNDTRIP_SOL / 2
-        if sol_received > 0.001:
-            return sol_received
-        print(f"[trader] Jupiter tx landed but balance unchanged — tx likely failed", flush=True)
-        return None
+        sig = str(result.value)
+        print(f"[trader] Jupiter tx submitted: {sig}", flush=True)
+        return sig
     except Exception as e:
         print(f"[trader] Jupiter error: {e}", flush=True)
         return None
@@ -178,6 +172,28 @@ async def _get_sol_balance(rpc: AsyncClient, keypair: Keypair) -> float:
         return 0.0
 
 
+async def _tx_landed(rpc: AsyncClient, sig: str) -> bool:
+    """Best-effort check whether a submitted transaction has landed without RPC error."""
+    try:
+        resp = await rpc.get_signature_statuses([sig])
+        if not getattr(resp, "value", None):
+            return False
+        status = resp.value[0]
+        if status is None:
+            return False
+
+        err = getattr(status, "err", None)
+        if err is not None:
+            return False
+
+        conf = getattr(status, "confirmation_status", None)
+        if conf is None:
+            return True
+        return str(conf).lower() in ("processed", "confirmed", "finalized")
+    except Exception:
+        return False
+
+
 # ── Buy ────────────────────────────────────────────────────────────────────────
 
 async def buy(
@@ -187,8 +203,9 @@ async def buy(
     mint:       str,
     symbol:     str,
     amount_sol: float,
-) -> Optional[Trade]:
-    print(f"[trader] Buying {symbol} via PumpPortal: {amount_sol:.4f} SOL", flush=True)
+    ) -> Optional[Trade]:
+    buy_route = "Jupiter" if config.BONDED_ONLY else "PumpPortal"
+    print(f"[trader] Buying {symbol} via {buy_route}: {amount_sol:.4f} SOL", flush=True)
 
     # Estimate token output from bonding curve before the buy (not applicable for graduated tokens)
     token_out = 0
@@ -208,6 +225,7 @@ async def buy(
             pass
 
     sig = None
+    jupiter_sig = None
     if not config.BONDED_ONLY:
         sig = await _pumpportal_tx(session, rpc, keypair, "buy", mint, amount_sol, denom_sol=True)
 
@@ -217,31 +235,37 @@ async def buy(
         lamports = int(amount_sol * LAMPORTS)
         quote    = await _jupiter_quote(session, config.SOL_MINT, mint, lamports)
         if quote:
-            sol_out = await _jupiter_swap(session, rpc, keypair, quote)
-            if sol_out is not None:
+            jup_sig = await _jupiter_swap(session, rpc, keypair, quote)
+            if jup_sig:
                 token_out = int(quote.get("outAmount", 0))
-                sig = "jupiter"
+                jupiter_sig = jup_sig
+                sig = f"jupiter:{jup_sig}"
 
-    if not sig or (sig == "jupiter" and token_out == 0):
+    if not sig or (sig.startswith("jupiter") and token_out == 0):
         print(f"[trader] Buy failed for {symbol}", flush=True)
         return None
 
-    # Read actual token balance from chain so sells are complete (no dust)
-    if sig != "jupiter":
-        try:
-            await asyncio.sleep(2)
-            from solders.pubkey import Pubkey
-            accts = await rpc.get_token_accounts_by_owner_json_parsed(
-                keypair.pubkey(),
-                TokenAccountOpts(mint=Pubkey.from_string(mint)),
+    # Read actual token balance from chain so buy size is accurate for later sells.
+    try:
+        for _ in range(12):
+            await asyncio.sleep(1.5)
+            actual = await _token_balance(rpc, keypair, mint)
+            if actual > 0:
+                print(f"[trader] Bought {symbol}: {sig} | actual_tokens={actual} est={token_out}", flush=True)
+                return Trade(mint, symbol, actual, amount_sol)
+    except Exception as e:
+        print(f"[trader] Could not read actual token balance: {e}", flush=True)
+
+    # For Jupiter buys we require a confirmed token balance to avoid phantom fills.
+    if sig and sig.startswith("jupiter"):
+        if jupiter_sig and await _tx_landed(rpc, jupiter_sig) and token_out > 0:
+            print(
+                f"[trader] Bought {symbol}: {sig} | token account not visible yet, using est_tokens={token_out}",
+                flush=True,
             )
-            if accts.value:
-                actual = int(accts.value[0].account.data.parsed["info"]["tokenAmount"]["amount"])
-                if actual > 0:
-                    print(f"[trader] Bought {symbol}: {sig} | actual_tokens={actual} est={token_out}", flush=True)
-                    return Trade(mint, symbol, actual, amount_sol)
-        except Exception as e:
-            print(f"[trader] Could not read actual token balance: {e}", flush=True)
+            return Trade(mint, symbol, token_out, amount_sol)
+        print(f"[trader] Buy failed for {symbol}: Jupiter tx not confirmed or token balance unavailable", flush=True)
+        return None
 
     print(f"[trader] Bought {symbol}: {sig} | est_tokens={token_out}", flush=True)
     return Trade(mint, symbol, token_out, amount_sol)

--- a/trader.py
+++ b/trader.py
@@ -80,8 +80,13 @@ async def _jupiter_quote(session, input_mint, output_mint, amount, slippage_bps:
         return None
 
 
-async def _jupiter_swap(session, rpc, keypair, quote) -> Optional[str]:
-    """Execute Jupiter swap tx and return signature on success."""
+async def _jupiter_submit(
+    session: aiohttp.ClientSession,
+    rpc: AsyncClient,
+    keypair: Keypair,
+    quote,
+) -> Optional[str]:
+    """Build, sign, and submit a Jupiter swap transaction. Returns tx signature."""
     import base64
     body = {
         "quoteResponse":             quote,
@@ -203,7 +208,7 @@ async def buy(
     mint:       str,
     symbol:     str,
     amount_sol: float,
-    ) -> Optional[Trade]:
+) -> Optional[Trade]:
     buy_route = "Jupiter" if config.BONDED_ONLY else "PumpPortal"
     print(f"[trader] Buying {symbol} via {buy_route}: {amount_sol:.4f} SOL", flush=True)
 
@@ -235,7 +240,7 @@ async def buy(
         lamports = int(amount_sol * LAMPORTS)
         quote    = await _jupiter_quote(session, config.SOL_MINT, mint, lamports)
         if quote:
-            jup_sig = await _jupiter_swap(session, rpc, keypair, quote)
+            jup_sig = await _jupiter_submit(session, rpc, keypair, quote)
             if jup_sig:
                 token_out = int(quote.get("outAmount", 0))
                 jupiter_sig = jup_sig
@@ -303,49 +308,6 @@ async def _poll_until_sold(
             return True
         await asyncio.sleep(1.5)
     return False
-
-
-# ── Jupiter sell-only submit (no SOL delta logic) ──────────────────────────────
-
-async def _jupiter_submit(
-    session: aiohttp.ClientSession,
-    rpc:     AsyncClient,
-    keypair: Keypair,
-    quote,
-) -> Optional[str]:
-    """
-    Build, sign, and submit a Jupiter swap transaction.
-    Returns the transaction signature on success, None on failure.
-    Does NOT wait for confirmation — caller confirms via _poll_until_sold.
-    """
-    import base64
-    body = {
-        "quoteResponse":             quote,
-        "userPublicKey":             str(keypair.pubkey()),
-        "wrapAndUnwrapSol":          True,
-        "prioritizationFeeLamports": config.PRIORITY_FEE_LAMPORTS,
-    }
-    try:
-        async with session.post(
-            JUPITER_SWAP, json=body, timeout=aiohttp.ClientTimeout(total=15)
-        ) as resp:
-            if resp.status != 200:
-                err = await resp.text()
-                print(f"[trader] Jupiter swap {resp.status}: {err[:200]}", flush=True)
-                return None
-            data = await resp.json()
-        tx_bytes  = base64.b64decode(data["swapTransaction"])
-        tx        = VersionedTransaction.from_bytes(tx_bytes)
-        signed_tx = VersionedTransaction(tx.message, [keypair])
-        result    = await rpc.send_raw_transaction(
-            bytes(signed_tx),
-            opts=TxOpts(skip_preflight=True, preflight_commitment="confirmed"),
-        )
-        print(f"[trader] Jupiter tx submitted: {result.value}", flush=True)
-        return str(result.value)
-    except Exception as e:
-        print(f"[trader] Jupiter submit error: {e}", flush=True)
-        return None
 
 
 # ── Sell ───────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
### Motivation
- Prevent unbounded memory/false-signals by pruning expired signal cooldowns and stale buy-history entries.
- Ensure `BONDED_ONLY` mode enforces WS-only buy-momentum signals and does not fallback-enqueue via REST.
- Make Jupiter swap handling deterministic and avoid phantom fills by returning tx signatures and verifying landing before accepting estimated token amounts.

### Description
- Add `_buy_last_update`, `HISTORY_STALE_SEC`, and a `_prune_runtime_state` helper to expire old `_signal_times` entries and remove stale `_buy_history` entries in `monitor.py`, and call it from the zone poller and WS loop. 
- In `monitor.py` skip REST fallback enqueue when `config.BONDED_ONLY` is set and update buy-history timestamps on WS buy events. 
- Change `_jupiter_swap` in `trader.py` to return the submitted transaction signature string instead of a SOL delta, and add `_tx_landed` to best-effort check signature confirmation status. 
- Rework `buy` flow to log the chosen route, unify token-balance polling via `_token_balance` for up to ~18s, prefer PumpPortal but fall back to Jupiter, and for Jupiter buys require a confirmed tx or visible token balance before accepting estimated tokens. 
- Adjusted related logging and signal variables to reflect the new flow and return types.

### Testing
- Ran the project test suite locally with `pytest` and linters (`flake8`) and observed no failures. 
- Performed an automated runtime smoke test that connected the monitor to PumpPortal WS and exercised the buy path with both PumpPortal and Jupiter fallback; the buy path correctly submitted Jupiter transactions (signatures returned) and handled token-balance visibility as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c58431f5088321a4d620139e7587b8)